### PR TITLE
feat(web): 增加点击头像查看原图功能

### DIFF
--- a/src/web/components/modals/UserProfile.tsx
+++ b/src/web/components/modals/UserProfile.tsx
@@ -14,6 +14,7 @@ import { useTRPGSelector, useTRPGDispatch } from '@redux/hooks/useTRPGSelector';
 import { useHistory } from 'react-router';
 import { sendFriendRequest } from '@redux/actions/user';
 import { addConverse } from '@redux/actions/chat';
+import ImageViewer from '../ImageViewer';
 
 const Root = styled.div`
   padding: 8px;
@@ -96,12 +97,25 @@ export const UserProfile: React.FC<UserProfileProps> = TMemo((props) => {
     dispatch(sendFriendRequest(userUUID));
   }, [userUUID]);
 
+  const getAvatar = () => {
+    if (userInfo.avatar) {
+      return (
+        <ImageViewer
+          originImageUrl={userInfo.avatar!.replace('/thumbnail', '')}
+        >
+          <InfoAvatar src={userInfo.avatar} name={name} />
+        </ImageViewer>
+      );
+    }
+    return <InfoAvatar src={userInfo.avatar} name={name} />;
+  };
+
   return (
     <Root>
       <Info>
         <Col>
           <Row>
-            <InfoAvatar src={userInfo.avatar} name={name} />
+            {getAvatar()}
             <InfoText>
               <div>{name}</div>
               <InfoTextSub>{userInfo.username}</InfoTextSub>


### PR DESCRIPTION
## Summary
* 在`UserProfile`中使用`ImageViewer`实现查看头像原图功能。
  * 只对自定义头像适用。

## Test Plan
![image](https://user-images.githubusercontent.com/4232536/120743238-78341e80-c4ad-11eb-97a7-0db7298185ac.png)
![image](https://user-images.githubusercontent.com/4232536/120743259-897d2b00-c4ad-11eb-8bc5-9c5b17a9b2f0.png)




